### PR TITLE
a modification in order to install the pygcn.service file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include gcn/_version.py
+recursive-include data *

--- a/data/systemd/pygcn.service
+++ b/data/systemd/pygcn.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=PyGCN service
+
+[Service]
+Nice=18
+ExecStart=pygcn-listen
+
+[Install]
+WantedBy=default.target
+

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ for a in sys.argv:
     if a.startswith("--user"):
         user_install = True
 
-systemd_target_dir = "/usr/local/lib/systemd/user"
+systemd_target_dir = "/usr/lib/systemd/user"
 if user_install:
     systemd_target_dir = os.environ["HOME"] + "/.local/share/systemd/user"
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@
 
 import ast
 import sys
+import os
 
 from setuptools import setup
 import versioneer
@@ -29,8 +30,18 @@ with open('gcn/__init__.py') as f:
     mod = ast.parse(f.read())
 __doc__ = ast.get_docstring(mod)
 
+user_install = False
+for a in sys.argv:
+    if a.startswith("--user"):
+        user_install = True
+
+systemd_target_dir = "/usr/local/lib/systemd/user"
+if user_install:
+    systemd_target_dir = os.environ["HOME"] + "/.local/share/systemd/user"
+
 setup(description=__doc__.splitlines()[1],
       long_description=__doc__,
       setup_requires=setup_requires,
       version=versioneer.get_version(),
-      cmdclass=versioneer.get_cmdclass())
+      cmdclass=versioneer.get_cmdclass(),
+      data_files=[(systemd_target_dir , ["data/systemd/pygcn.service"])])


### PR DESCRIPTION
(from Hubert)

Please note:

- I only used the pygcn-client in pygcn.service. Both pygcn-
client.service and pygcn-serve.client might be useful. And maybe with
different install locations.

- the install location for data files has to be absolute in order to be
installed in the system. Otherwise it is packaged as a subdirectory of
the python package

- this only an example where I hardcode the "/usr" prefix. A nice
approach would be to set the default installation prefix for the system
to "/usr/local" (the regular default) and then parse the "--prefix"
arguments passed to the setup.py script.

As said above, this is only a proposal.